### PR TITLE
Fix .cancel()

### DIFF
--- a/src/createApiEpic.js
+++ b/src/createApiEpic.js
@@ -1,5 +1,5 @@
 import { empty, of, merge, Subject } from 'rxjs';
-import { catchError, filter, map, switchMap, takeUntil } from 'rxjs/operators';
+import { catchError, filter, map, switchMap } from 'rxjs/operators';
 import { ajax } from 'rxjs/ajax';
 import xhr2 from 'xhr2';
 
@@ -50,7 +50,6 @@ export default function createApiEpic(id, handler, getCBStream) {
 						state$.value,
 					);
 				}),
-				takeUntil(cancel$),
 			),
 			// callApi actions
 			action$.pipe(
@@ -82,7 +81,6 @@ export default function createApiEpic(id, handler, getCBStream) {
 						),
 					);
 				}),
-				takeUntil(cancel$),
 			),
 		);
 	};

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -28,6 +28,19 @@ export default function apiReducer(state = {}, action) {
 		};
 	}
 
+	if (type === `${actionPrefix}/cancel`) {
+		return {
+			...state,
+			[id]: {
+				...state[id],
+				done: false,
+				error: null,
+				pending: false,
+				progress: 1,
+			},
+		};
+	}
+
 	if (type === `${actionPrefix}/error`) {
 		return {
 			...state,


### PR DESCRIPTION
1.

If you cancel a request the state should reflect this and set things
like pending to false.

2.
Calling .cancel() shouldn't stop any future api calls from being
processed. So it shouldn't stop the whole epic. API users should handle
the .cancel() themselves by listening to the cancel$ stream.

For example:
```js
export const createGameVersionPoll = createAuthorizedApiEpic(
  'game/create_game_version_poll',
  (callApi, { gameId, versionId }) => callApi({
    url: getApiUrl('devs', `games/${gameId}/versions/${versionId}/_poll`),
    method: 'GET',
  }),
  ({ success$, cancel$ }) => (
    success$.pipe(
      switchMap(({ payload: { result: { response } } }) => {
        const { game_id: gameId, version_id: versionId } = response;

        if (response.state === 'done') return empty();

        return of(createGameVersionPoll.fetch({ gameId, versionId })).pipe(
          delay(1000),
        );
      }),
      takeUntil(cancel$),
    )
  ),
);
```