### PR TITLE
Allow epic caching through a new cacheSeconds option

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	},
 	"author": "Prokos <awsumthx@gmail.com>",
 	"dependencies": {
+		"object-hash": "^2.1.1",
 		"xhr2": "^0.2.0"
 	},
 	"peerDependencies": {

--- a/src/createApiEpic.js
+++ b/src/createApiEpic.js
@@ -2,18 +2,26 @@ import { empty, of, merge, Subject } from 'rxjs';
 import { catchError, filter, map, switchMap, takeUntil } from 'rxjs/operators';
 import { ajax } from 'rxjs/ajax';
 import xhr2 from 'xhr2';
+import objectHash from 'object-hash';
 
 import {
 	createActionCreator,
 } from './actions';
 
-export default function createApiEpic(id, handler, getCBStream) {
+const cache = {};
+
+export default function createApiEpic(id, handler, getCBStream, options = {}) {
+	const { cacheSeconds = 0 } = options;
+
+	const doCache = cacheSeconds > 0;
+
 	const defaultState = {
 		session: {},
 	};
 
-	const fetch = (options, _getCBStream) => createActionCreator(`fetch/${id}`)({ options, getCBStream: _getCBStream });
+	const attemptFetch = (options, _getCBStream) => createActionCreator(`attemptFetch/${id}`)({ options, getCBStream: _getCBStream });
 
+	const fetch = createActionCreator(`fetch/${id}`);
 	const cancel = createActionCreator(`cancel/${id}`);
 	const error = createActionCreator(`error/${id}`);
 	const progress = createActionCreator(`progress/${id}`);
@@ -29,12 +37,26 @@ export default function createApiEpic(id, handler, getCBStream) {
 		const streams = { cancel$, success$, error$, progress$ };
 
 		const epicCbStream$ = getCBStream ? getCBStream(streams) : empty();
-		const fetchType = fetch().type;
 
 		return merge(
+			// attemptFetch actions
+			action$.pipe(
+				filter(action => action.type === attemptFetch().type),
+				switchMap(action => {
+					const cacheKey = objectHash({ type: action.type, options: action.payload.options });
+					const cacheInfo = cache[cacheKey];
+					if (doCache && cacheInfo && (Date.now() - cacheInfo.time) < (cacheSeconds * 1000)) {
+						// We're still within the cache period, immediately go to success
+						return of(success({ result: cacheInfo.result, options: action.payload.options, fromCache: true }));
+					}
+
+					// Otherwise just go and fetch!
+					return of(fetch({ ...action.payload, cacheKey }));
+				}),
+			),
 			// apiFetch actions
 			action$.pipe(
-				filter(action => action.type === fetchType),
+				filter(action => action.type === fetch.type),
 				switchMap(action => {
 					const callApiCreator = payload => of({
 						...callApi(payload),
@@ -59,7 +81,7 @@ export default function createApiEpic(id, handler, getCBStream) {
 				switchMap(action => {
 					const progressSubscriber$ = new Subject();
 					const fetchAction = action.__fetchAction;
-					const actionCbStream$ = fetchAction && fetchAction.payload && fetchAction.payload.getCBStream ? fetchAction.payload.getCBStream(streams) : empty();
+					const actionCbStream$ = fetchAction.payload.getCBStream ? fetchAction.payload.getCBStream(streams) : empty();
 
 					return merge(
 						// Action callback stream
@@ -78,8 +100,18 @@ export default function createApiEpic(id, handler, getCBStream) {
 							crossDomain: true,
 							progressSubscriber: progressSubscriber$,
 						}).pipe(
-							switchMap(result => of(success({ result, options: fetchAction && fetchAction.payload ? fetchAction.payload.options : undefined }))),
-							catchError(result => of(error({ result, options: fetchAction && fetchAction.payload ? fetchAction.payload.options : undefined }))),
+							switchMap(result => {
+								// Set cache
+								if (doCache) {
+									cache[fetchAction.payload.cacheKey] = {
+										time: Date.now(),
+										result,
+									};
+								}
+
+								return of(success({ result, options: fetchAction.payload.options, fromCache: false }));
+							}),
+							catchError(result => of(error({ result, options: fetchAction.payload.options }))),
 						),
 					).pipe(
 						takeUntil(cancel$),
@@ -93,7 +125,7 @@ export default function createApiEpic(id, handler, getCBStream) {
 	epic.progress = progress;
 	epic.cancel = cancel;
 	epic.error = error;
-	epic.fetch = fetch;
+	epic.fetch = attemptFetch;
 	epic.id = id;
 
 	return epic;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3050,6 +3050,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.1.1.tgz#9447d0279b4fcf80cff3259bf66a1dc73afabe09"
+  integrity sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==
+
 object-inspect@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.6.0.tgz#c70b6cbf72f274aab4c34c0c82f5167bf82cf15b"


### PR DESCRIPTION
1. Adds a 4th parameter to `createApiEpic` that contains any `options`
2. Adds a `cacheSeconds` option that when set will not re-run the given epic again within that timeframe, but instead immediately emit `success` with the cached results.

Results are cached from the time they are successful, not from the time they are fetched.

Errors are not cached.